### PR TITLE
TOC link and contents update

### DIFF
--- a/content/en/docs/writing-markdown-latex.md
+++ b/content/en/docs/writing-markdown-latex.md
@@ -498,6 +498,7 @@ Here's some important information...
 
 ## Table of Contents
 
-A table of contents may be particularly useful for long posts or tutorial/documentation type content. Use the `{{%/* toc */%}}` shortcode anywhere you wish within your Markdown content to automatically generate a table of contents.
+A table of contents may be particularly useful for long posts or tutorial/documentation type content. Use the `<html> {{%/* toc */%}} </html>` shortcode anywhere you wish within your Markdown content to automatically generate a table of contents.  
 
 _Note: the `toc` shortcode may not yet function correctly in **Hugo v0.60+** due to a known Hugo limitation. As a temporary workaround, `markup: blackfriday` can be added to a page's front matter to enable use of `toc` shortcode._
+_Note: the `toc` shortcode only works with markdown headers (i.e. `#` for Header 1), if html header tags are used, they will not show up in the table of contents._


### PR DESCRIPTION
The toc link needs to be placed inside html code; if it is not - it disrupts the markdown code.  Also, noted that you need to use the markdown header tags for the item to show up in the toc.